### PR TITLE
Add runtime wallet configuration and automatic LP/hedge management

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,15 @@ Bot de hedge para posições de LP WETH/USDC na Uniswap v3 com integração à H
 
 1. Copie `.env.example` para `.env` e preencha as variáveis.
 2. Instale dependências: `pip install -r requirements.txt`.
-3. Execute o bot: `python main.py`.
+3. Execute o bot: `python main.py` e escolha entre carteira de **teste** ou **real** quando solicitado.
+   Ao usar o modo de teste será pedido o saldo inicial de ETH e USDC a ser utilizado.
 
 ## Modo de simulação
 
-Defina `SIMULATED_WALLET_MODE=True` para testar sem enviar transações reais. Mesmo em simulação o bot consulta dados reais das APIs.
+Durante a execução, o bot perguntará se deve utilizar uma carteira de teste (simulada) ou real.
+Para automatizar, defina `SIMULATED_WALLET_MODE=True` ou `False` no `.env` e a pergunta será pulada.
+Mesmo em simulação o bot consulta dados reais das APIs.
+
+Ao iniciar um ciclo o bot verifica se já existem posições de LP na Uniswap e de hedge na Hyperliquid,
+criando-as se necessário. A troca de faixa da LP considera o possível ganho em taxas menos o custo de gas,
+e o hedge é ajustado dinamicamente para manter exposição neutra.

--- a/main.py
+++ b/main.py
@@ -8,10 +8,25 @@ from utils.logic import BotLogic
 load_dotenv()
 
 ADDRESS = os.getenv("PUBLIC_ADDRESS", "0x0000000000000000000000000000000000000000")
-SIMULATED = os.getenv("SIMULATED_WALLET_MODE", "True") == "True"
-INTERVAL = int(os.getenv("POLL_INTERVAL", "60"))
+interval_env = os.getenv("POLL_INTERVAL", "60")
+INTERVAL = int(interval_env)
 
-wallet = WalletSimulator() if SIMULATED else None
+simulated_env = os.getenv("SIMULATED_WALLET_MODE")
+if simulated_env is None:
+    choice = input("Usar carteira de 'teste' ou 'real'? [teste/real]: ").strip().lower()
+    SIMULATED = choice != "real"
+else:
+    SIMULATED = simulated_env.lower() == "true"
+
+wallet = None
+if SIMULATED:
+    try:
+        eth_bal = float(input("Saldo inicial de ETH para testes: ") or "10")
+        usdc_bal = float(input("Saldo inicial de USDC para testes: ") or "10000")
+    except ValueError:
+        eth_bal, usdc_bal = 10.0, 10000.0
+    wallet = WalletSimulator(initial_eth=eth_bal, initial_usdc=usdc_bal)
+
 bot = BotLogic(wallet, ADDRESS, simulated=SIMULATED)
 
 send_telegram_message("🚀 Bot iniciado com sucesso!")

--- a/utils/hyperliquid.py
+++ b/utils/hyperliquid.py
@@ -3,8 +3,10 @@ import requests
 BASE_URL = "https://api.hyperliquid.xyz"
 
 
-def get_eth_position(address: str) -> float:
+def get_eth_position(address: str, wallet=None) -> float:
     """Return ETH exposure on Hyperliquid for given address."""
+    if wallet is not None and wallet.hedge_positions:
+        return wallet.hedge_positions[0]["eth"]
     try:
         resp = requests.get(f"{BASE_URL}/positions?user={address}", timeout=10)
         data = resp.json()

--- a/utils/logic.py
+++ b/utils/logic.py
@@ -1,6 +1,11 @@
 import os
 from .prices import get_eth_usdc_price
-from .uniswap import get_lp_position, create_lp_position, move_range, exit_position
+from .uniswap import (
+    get_lp_position,
+    create_lp_position,
+    move_range,
+    should_reposition,
+)
 from .hyperliquid import get_eth_position, set_hedge_position
 from .telegram import send_telegram_message
 
@@ -10,8 +15,6 @@ class BotLogic:
         self.wallet = wallet
         self.address = address
         self.simulated = simulated
-        self.upper_strategy = os.getenv("UPPER_STRATEGY", "move")
-        self.lower_strategy = os.getenv("LOWER_STRATEGY", "move")
 
     def run_cycle(self):
         price = get_eth_usdc_price()
@@ -22,34 +25,29 @@ class BotLogic:
             lp = create_lp_position(self.wallet, price)
             send_telegram_message("LP criada automaticamente")
 
-        hedge_eth = get_eth_position(self.address)
-        exposure = lp["eth"] - hedge_eth
-        if abs(exposure) > 0.01:
-            set_hedge_position(lp["eth"], price, self.simulated, self.wallet)
-            send_telegram_message("Hedge rebalanceado")
-
         lower_price, upper_price = lp["lower"], lp["upper"]
-        # Detect if values are ticks (large integers) and convert to prices
         if abs(lower_price) > 1e5 or abs(upper_price) > 1e5:
             lower_price = self._tick_to_price(lp["lower"])
             upper_price = self._tick_to_price(lp["upper"])
+        lp_prices = {
+            "lower": lower_price,
+            "upper": upper_price,
+            "usdc": lp["usdc"],
+            "eth": lp["eth"],
+        }
 
-        if price > upper_price * 0.99:
-            if self.upper_strategy == "swap":
-                exit_position(self.wallet)
-                self.wallet.swap("USDC", "ETH", lp["usdc"], price)
-                send_telegram_message("Swap total para ETH executado")
-            else:
-                move_range(self.wallet, price)
-                send_telegram_message("Range movido para cima")
-        elif price < lower_price * 1.01:
-            if self.lower_strategy == "swap":
-                exit_position(self.wallet)
-                self.wallet.swap("ETH", "USDC", lp["eth"], price)
-                send_telegram_message("Swap total para USDC executado")
-            else:
-                move_range(self.wallet, price)
-                send_telegram_message("Range movido para baixo")
+        hedge_eth = get_eth_position(self.address, self.wallet)
+        if hedge_eth == 0 and lp["eth"] > 0:
+            set_hedge_position(lp["eth"], price, self.simulated, self.wallet)
+            send_telegram_message("Hedge criado automaticamente")
+            hedge_eth = lp["eth"]
+        elif abs(lp["eth"] - hedge_eth) > 0.01:
+            set_hedge_position(lp["eth"], price, self.simulated, self.wallet)
+            send_telegram_message("Hedge rebalanceado")
+
+        if should_reposition(price, lp_prices):
+            move_range(self.wallet, price)
+            send_telegram_message("Range reposicionado")
 
         print(
             f"LP: [{lower_price:.2f}, {upper_price:.2f}] Exposição: {lp['eth']:.4f} ETH Hedge: {hedge_eth:.4f}"

--- a/utils/uniswap.py
+++ b/utils/uniswap.py
@@ -32,32 +32,54 @@ def get_lp_position(address: str):
     return None
 
 
+def should_reposition(price: float, lp: dict, fee_rate: float = 0.0005) -> bool:
+    """Decide whether moving the LP range is worth the gas cost."""
+    gas_cost = float(os.getenv("GAS_COST_USD", "5"))
+    center = (lp["lower"] + lp["upper"]) / 2
+    deviation = abs(price - center) / center
+    potential_fee = lp["usdc"] * fee_rate * deviation
+    return potential_fee > gas_cost or price < lp["lower"] or price > lp["upper"]
+
+
 def create_lp_position(wallet, price: float, width: float = 0.05):
     """Create LP position around current price."""
     lower = price * (1 - width)
     upper = price * (1 + width)
     eth_amount = 1.0
     usdc_amount = eth_amount * price
-    wallet.create_lp_position(lower, upper, eth_amount, usdc_amount)
+    if wallet is not None:
+        wallet.create_lp_position(lower, upper, eth_amount, usdc_amount)
+    else:
+        print(
+            f"[UNISWAP] Would create LP with {eth_amount} ETH / {usdc_amount} USDC between {lower}-{upper}"
+        )
     return {"lower": lower, "upper": upper, "eth": eth_amount, "usdc": usdc_amount}
 
 
 def move_range(wallet, price: float, width: float = 0.05):
     """Move LP range to be centered around current price."""
+    lower = price * (1 - width)
+    upper = price * (1 + width)
+    if wallet is None:
+        print(f"[UNISWAP] Would move range to {lower}-{upper}")
+        return {"lower": lower, "upper": upper, "eth": 0, "usdc": 0}
     if not wallet.lp_positions:
         return create_lp_position(wallet, price, width)
     lp = wallet.lp_positions[0]
     wallet.lp_positions[0] = {
-        "lower": price * (1 - width),
-        "upper": price * (1 + width),
+        "lower": lower,
+        "upper": upper,
         "eth": lp["eth"],
         "usdc": lp["usdc"],
     }
-    print(f"[SIM] Range moved to {price * (1 - width)}-{price * (1 + width)}")
+    print(f"[SIM] Range moved to {lower}-{upper}")
     return wallet.lp_positions[0]
 
 
 def exit_position(wallet):
+    if wallet is None:
+        print("[UNISWAP] Would exit LP position")
+        return
     if wallet.lp_positions:
         pos = wallet.lp_positions.pop(0)
         wallet.eth_balance += pos["eth"]


### PR DESCRIPTION
## Summary
- prompt for ETH and USDC balances when running in test mode
- auto-create LP and hedge positions and rebalance hedge as needed
- evaluate LP range shifts against gas costs before moving

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `POLL_INTERVAL=1 python main.py` (teste)
- `POLL_INTERVAL=1 python main.py` (real)


------
https://chatgpt.com/codex/tasks/task_e_689547d2bc1c83278aa363929c3aa08d