### PR TITLE
Handle missing price data gracefully

### DIFF
--- a/utils/prices.py
+++ b/utils/prices.py
@@ -1,3 +1,4 @@
+import os
 import requests
 
 # Uniswap v3 pool on Arbitrum for WETH/USDC 0.05%
@@ -16,7 +17,14 @@ def get_eth_usdc_price() -> float:
         return float(data)
     except Exception:
         # Fallback using Binance price if subgraph fails
-        resp = requests.get(
-            "https://api.binance.com/api/v3/ticker/price", params={"symbol": "ETHUSDT"}, timeout=10
-        )
-        return float(resp.json()["price"])
+        try:
+            resp = requests.get(
+                "https://api.binance.com/api/v3/ticker/price",
+                params={"symbol": "ETHUSDT"},
+                timeout=10,
+            )
+            return float(resp.json()["price"])
+        except Exception:
+            # Final fallback to environment variable or default value
+            fallback = os.getenv("FALLBACK_ETH_PRICE", "2000")
+            return float(fallback)


### PR DESCRIPTION
## Summary
- Add offline fallback for ETH/USDC price retrieval when external APIs fail

## Testing
- `SIMULATED_WALLET_MODE=true POLL_INTERVAL=5 FALLBACK_ETH_PRICE=1234 python main.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68954eaddc488327821a156585018974