### PR TITLE
Handle missing price data gracefully and respect simulated balances

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,8 +7,13 @@ from utils.logic import BotLogic
 
 load_dotenv()
 
-ADDRESS = os.getenv("PUBLIC_ADDRESS", "0x0000000000000000000000000000000000000000")
-interval_env = os.getenv("POLL_INTERVAL", "60")
+ADDRESS = os.getenv("PUBLIC_ADDRESS")
+if not ADDRESS:
+    ADDRESS = (
+        input("Endereço público para monitorar (enter para nenhum): ").strip()
+        or "0x0000000000000000000000000000000000000000"
+    )
+interval_env = os.getenv("POLL_INTERVAL", "30")
 INTERVAL = int(interval_env)
 
 simulated_env = os.getenv("SIMULATED_WALLET_MODE")
@@ -18,14 +23,27 @@ if simulated_env is None:
 else:
     SIMULATED = simulated_env.lower() == "true"
 
+subgraph = os.getenv("UNISWAP_SUBGRAPH") or input(
+    "URL do subgrafo Uniswap (enter para padrão Arbitrum): "
+).strip()
+if not subgraph:
+    subgraph = "https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-arbitrum"
+os.environ["UNISWAP_SUBGRAPH"] = subgraph
+
+pool = os.getenv("UNISWAP_POOL_ID") or input(
+    "ID da pool Uniswap (enter para WETH/USDC 0.05%): "
+).strip()
+if not pool:
+    pool = "0x88f38662f45c78302b556271cd0a4da9d1cb1a0d"
+os.environ["UNISWAP_POOL_ID"] = pool
+
 wallet = None
 if SIMULATED:
     try:
-        eth_bal = float(input("Saldo inicial de ETH para testes: ") or "10")
         usdc_bal = float(input("Saldo inicial de USDC para testes: ") or "10000")
     except ValueError:
-        eth_bal, usdc_bal = 10.0, 10000.0
-    wallet = WalletSimulator(initial_eth=eth_bal, initial_usdc=usdc_bal)
+        usdc_bal = 10000.0
+    wallet = WalletSimulator(initial_usdc=usdc_bal)
 
 bot = BotLogic(wallet, ADDRESS, simulated=SIMULATED)
 

--- a/utils/hyperliquid.py
+++ b/utils/hyperliquid.py
@@ -19,10 +19,12 @@ def get_eth_position(address: str, wallet=None) -> float:
     return 0.0
 
 
-def set_hedge_position(target_eth: float, price: float, simulated: bool, wallet=None) -> None:
+def set_hedge_position(
+    target_eth: float, price: float, simulated: bool, wallet=None, leverage: float = 5.0
+) -> None:
     """Adjust hedge position to target ETH exposure."""
     if simulated and wallet is not None:
-        wallet.rebalance_hedge(target_eth)
+        wallet.rebalance_hedge(target_eth, price, leverage)
         return
 
     # Placeholder for real trading logic

--- a/utils/logic.py
+++ b/utils/logic.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 from .prices import get_eth_usdc_price
 from .uniswap import (
     get_lp_position,
@@ -18,12 +19,23 @@ class BotLogic:
 
     def run_cycle(self):
         price = get_eth_usdc_price()
-        send_telegram_message(f"Preço atual ETH/USDC: {price:.2f}")
 
         lp = get_lp_position(self.address)
+        if lp and self.wallet is not None and not self.wallet.lp_positions:
+            self.wallet.lp_positions.append(lp)
+            ts = datetime.utcnow().strftime("%H:%M:%S")
+            send_telegram_message(
+                f"[{ts}] LP existente detectada {lp['lower']:.2f}-{lp['upper']:.2f}"
+            )
+
         if not lp:
-            lp = create_lp_position(self.wallet, price)
-            send_telegram_message("LP criada automaticamente")
+            alloc = float(os.getenv("LP_ALLOCATION", "0.5"))
+            lp = create_lp_position(self.wallet, price, allocation=alloc)
+            ts = datetime.utcnow().strftime("%H:%M:%S")
+            send_telegram_message(
+                f"[{ts}] LP criada {lp['lower']:.2f}-{lp['upper']:.2f} "
+                f"com {lp['eth']:.4f} ETH / {lp['usdc']:.2f} USDC",
+            )
 
         lower_price, upper_price = lp["lower"], lp["upper"]
         if abs(lower_price) > 1e5 or abs(upper_price) > 1e5:
@@ -37,20 +49,31 @@ class BotLogic:
         }
 
         hedge_eth = get_eth_position(self.address, self.wallet)
-        if hedge_eth == 0 and lp["eth"] > 0:
-            set_hedge_position(lp["eth"], price, self.simulated, self.wallet)
-            send_telegram_message("Hedge criado automaticamente")
-            hedge_eth = lp["eth"]
-        elif abs(lp["eth"] - hedge_eth) > 0.01:
-            set_hedge_position(lp["eth"], price, self.simulated, self.wallet)
-            send_telegram_message("Hedge rebalanceado")
+        leverage = float(os.getenv("PERP_LEVERAGE", "5"))
+        max_hedge = float("inf")
+        if self.wallet is not None:
+            max_hedge = (self.wallet.usdc_balance * leverage) / price
+        target = min(lp["eth"], max_hedge)
+        if abs(hedge_eth - target) > 0.01:
+            set_hedge_position(target, price, self.simulated, self.wallet, leverage)
+            ts = datetime.utcnow().strftime("%H:%M:%S")
+            send_telegram_message(
+                f"[{ts}] Hedge {hedge_eth:.4f} -> {target:.4f} ETH",
+            )
+            hedge_eth = target
 
         if should_reposition(price, lp_prices):
-            move_range(self.wallet, price)
-            send_telegram_message("Range reposicionado")
+            old_lower, old_upper = lp_prices["lower"], lp_prices["upper"]
+            lp_prices = move_range(self.wallet, price)
+            ts = datetime.utcnow().strftime("%H:%M:%S")
+            send_telegram_message(
+                f"[{ts}] Range {old_lower:.2f}-{old_upper:.2f} -> "
+                f"{lp_prices['lower']:.2f}-{lp_prices['upper']:.2f}"
+            )
+            lower_price, upper_price = lp_prices["lower"], lp_prices["upper"]
 
         print(
-            f"LP: [{lower_price:.2f}, {upper_price:.2f}] Exposição: {lp['eth']:.4f} ETH Hedge: {hedge_eth:.4f}"
+            f"LP: [{lower_price:.2f}, {upper_price:.2f}] Exposição: {lp_prices['eth']:.4f} ETH Hedge: {hedge_eth:.4f}"
         )
 
     @staticmethod

--- a/utils/logic.py
+++ b/utils/logic.py
@@ -39,8 +39,8 @@ class BotLogic:
 
         lower_price, upper_price = lp["lower"], lp["upper"]
         if abs(lower_price) > 1e5 or abs(upper_price) > 1e5:
-            lower_price = self._tick_to_price(lp["lower"])
-            upper_price = self._tick_to_price(lp["upper"])
+            lower_price = self._tick_to_price(lower_price)
+            upper_price = self._tick_to_price(upper_price)
         lp_prices = {
             "lower": lower_price,
             "upper": upper_price,
@@ -53,7 +53,7 @@ class BotLogic:
         max_hedge = float("inf")
         if self.wallet is not None:
             max_hedge = (self.wallet.usdc_balance * leverage) / price
-        target = min(lp["eth"], max_hedge)
+        target = min(lp_prices["eth"], max_hedge)
         if abs(hedge_eth - target) > 0.01:
             set_hedge_position(target, price, self.simulated, self.wallet, leverage)
             ts = datetime.utcnow().strftime("%H:%M:%S")
@@ -65,12 +65,12 @@ class BotLogic:
         if should_reposition(price, lp_prices):
             old_lower, old_upper = lp_prices["lower"], lp_prices["upper"]
             lp_prices = move_range(self.wallet, price)
+            lower_price, upper_price = lp_prices["lower"], lp_prices["upper"]
             ts = datetime.utcnow().strftime("%H:%M:%S")
             send_telegram_message(
                 f"[{ts}] Range {old_lower:.2f}-{old_upper:.2f} -> "
-                f"{lp_prices['lower']:.2f}-{lp_prices['upper']:.2f}"
+                f"{lower_price:.2f}-{upper_price:.2f}"
             )
-            lower_price, upper_price = lp_prices["lower"], lp_prices["upper"]
 
         print(
             f"LP: [{lower_price:.2f}, {upper_price:.2f}] Exposição: {lp_prices['eth']:.4f} ETH Hedge: {hedge_eth:.4f}"

--- a/utils/prices.py
+++ b/utils/prices.py
@@ -1,22 +1,55 @@
+import os
 import requests
 
-# Uniswap v3 pool on Arbitrum for WETH/USDC 0.05%
-SUBGRAPH_URL = "https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-arbitrum"
-POOL_ID = "0x88f38662f45c78302b556271cd0a4da9d1cb1a0d"  # example pool, may change
+# Default Uniswap v3 pool configuration
+DEFAULT_SUBGRAPH_URL = "https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-arbitrum"
+DEFAULT_POOL_ID = "0x88f38662f45c78302b556271cd0a4da9d1cb1a0d"
 
 
 def get_eth_usdc_price() -> float:
-    """Return current price of WETH in USDC using the Uniswap v3 subgraph."""
-    query = {
-        "query": f"{{ pool(id: \"{POOL_ID}\") {{ token1Price }} }}"
-    }
+    """Return current price of WETH in USDC.
+
+    Fetches from Binance first, then Uniswap. Falls back to an environment
+    variable or a hard-coded default if both sources fail.
+    """
+
+    # Try Binance
     try:
-        response = requests.post(SUBGRAPH_URL, json=query, timeout=10)
+        headers = {}
+        api_key = os.getenv("BINANCE_API_KEY")
+        if api_key:
+            headers["X-MBX-APIKEY"] = api_key
+        resp = requests.get(
+            "https://api.binance.com/api/v3/ticker/price",
+            params={"symbol": "ETHUSDT"},
+            headers=headers,
+            timeout=10,
+        )
+        return float(resp.json()["price"])
+    except Exception:
+        pass
+
+    # Fallback to Uniswap subgraph
+    subgraph_url = os.getenv("UNISWAP_SUBGRAPH", DEFAULT_SUBGRAPH_URL)
+    pool_id = os.getenv("UNISWAP_POOL_ID", DEFAULT_POOL_ID)
+    query = {"query": f"{{ pool(id: \"{pool_id}\") {{ token1Price }} }}"}
+    try:
+        response = requests.post(subgraph_url, json=query, timeout=10)
         data = response.json()["data"]["pool"]["token1Price"]
         return float(data)
     except Exception:
-        # Fallback using Binance price if subgraph fails
-        resp = requests.get(
-            "https://api.binance.com/api/v3/ticker/price", params={"symbol": "ETHUSDT"}, timeout=10
-        )
-        return float(resp.json()["price"])
+        pass
+
+    # Environment fallback or manual input
+    env_fallback = os.getenv("FALLBACK_ETH_PRICE")
+    if env_fallback:
+        print("[WARN] Usando preço de fallback do ambiente.")
+        return float(env_fallback)
+    try:
+        manual = float(input("Preço atual do ETH/USDC: "))
+        print("[WARN] Usando preço manual fornecido.")
+        return manual
+    except Exception:
+        print("[WARN] Usando preço de fallback padrão 2000.0")
+        return 2000.0
+

--- a/utils/wallet_simulator.py
+++ b/utils/wallet_simulator.py
@@ -1,8 +1,8 @@
 class WalletSimulator:
     """In-memory simulator for testing without sending transactions."""
 
-    def __init__(self, initial_eth: float = 10.0, initial_usdc: float = 10000.0):
-        self.eth_balance = initial_eth
+    def __init__(self, initial_usdc: float = 10000.0):
+        self.eth_balance = 0.0
         self.usdc_balance = initial_usdc
         self.lp_positions = []
         self.hedge_positions = []
@@ -31,6 +31,15 @@ class WalletSimulator:
             self.eth_balance += amount / price
         print(f"[SIM] Swap {amount} {from_token} para {to_token} @ {price}")
 
-    def rebalance_hedge(self, target_eth):
-        self.hedge_positions = [{"eth": target_eth}]
-        print(f"[SIM] Hedge ajustado para {target_eth} ETH")
+    def rebalance_hedge(self, target_eth, price, leverage):
+        margin_required = abs(target_eth) * price / leverage
+        if margin_required > self.usdc_balance:
+            margin_required = self.usdc_balance
+            target_eth = (margin_required * leverage) / price
+        self.usdc_balance -= margin_required
+        self.hedge_positions = [
+            {"eth": target_eth, "margin": margin_required, "leverage": leverage}
+        ]
+        print(
+            f"[SIM] Hedge ajustado para {target_eth} ETH com margem {margin_required} USDC"
+        )


### PR DESCRIPTION
## Summary
- Include timestamped Telegram updates when creating LP positions and adjusting hedge exposure
- Resolve merge conflicts and streamline price retrieval with Binance first, Uniswap second, and environment/manual fallbacks

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `SIMULATED_WALLET_MODE=true POLL_INTERVAL=5 UNISWAP_SUBGRAPH=https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-arbitrum UNISWAP_POOL_ID=0x88f38662f45c78302b556271cd0a4da9d1cb1a0d PUBLIC_ADDRESS=0x0000000000000000000000000000000000000000 FALLBACK_ETH_PRICE=2000 LP_ALLOCATION=0.5 PERP_LEVERAGE=5 python main.py <<'EOF'
1000
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68954eaddc488327821a156585018974