### PR TITLE
Add spectator mode with optional full automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@ Bot de hedge para posições de LP WETH/USDC na Uniswap v3 com integração à H
 
 1. Copie `.env.example` para `.env` e preencha as variáveis.
 2. Instale dependências: `pip install -r requirements.txt`.
-3. Execute o bot: `python main.py` e escolha entre carteira de **teste** ou **real** quando solicitado.
-   Ao usar o modo de teste será pedido o saldo inicial de ETH e USDC a ser utilizado.
+3. Execute o bot: `python main.py` e escolha o modo **spectator** ou **full**.
+   No modo spectator o bot apenas monitora as posições existentes e envia sugestões pelo Telegram.
+   O modo full executa as alterações automaticamente.
+   Também é possível escolher entre carteira de **teste** ou **real**; em teste será pedido o saldo
+   inicial de USDC a ser utilizado.
 
-## Modo de simulação
+## Modos de operação
 
-Durante a execução, o bot perguntará se deve utilizar uma carteira de teste (simulada) ou real.
-Para automatizar, defina `SIMULATED_WALLET_MODE=True` ou `False` no `.env` e a pergunta será pulada.
+`RUN_MODE` controla se o bot opera em modo espectador (`spectator`) ou totalmente automático (`full`).
+Já `SIMULATED_WALLET_MODE` define se as operações devem usar uma carteira simulada.
+Para automatizar estas escolhas, defina as variáveis no `.env`.
+
 Mesmo em simulação o bot consulta dados reais das APIs.
 
 Ao iniciar um ciclo o bot verifica se já existem posições de LP na Uniswap e de hedge na Hyperliquid,

--- a/utils/hyperliquid.py
+++ b/utils/hyperliquid.py
@@ -19,10 +19,12 @@ def get_eth_position(address: str, wallet=None) -> float:
     return 0.0
 
 
-def set_hedge_position(target_eth: float, price: float, simulated: bool, wallet=None) -> None:
+def set_hedge_position(
+    target_eth: float, price: float, simulated: bool, wallet=None, leverage: float = 5.0
+) -> None:
     """Adjust hedge position to target ETH exposure."""
     if simulated and wallet is not None:
-        wallet.rebalance_hedge(target_eth)
+        wallet.rebalance_hedge(target_eth, price, leverage)
         return
 
     # Placeholder for real trading logic

--- a/utils/logic.py
+++ b/utils/logic.py
@@ -1,3 +1,5 @@
+"""Core bot logic for managing Uniswap LP positions and hedge exposure."""
+
 import os
 from datetime import datetime
 from .prices import get_eth_usdc_price

--- a/utils/logic.py
+++ b/utils/logic.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 from .prices import get_eth_usdc_price
 from .uniswap import (
     get_lp_position,
@@ -11,24 +12,48 @@ from .telegram import send_telegram_message
 
 
 class BotLogic:
-    def __init__(self, wallet, address: str, simulated: bool = True):
+    """Encapsulates the core LP and hedge management workflow."""
+
+    def __init__(self, wallet, address: str, mode: str = "spectator", simulated: bool = True):
         self.wallet = wallet
         self.address = address
+        self.mode = mode
         self.simulated = simulated
 
+    @property
+    def _execute(self) -> bool:
+        return self.mode == "full"
+
     def run_cycle(self):
+        """Execute one monitoring cycle and act on LP and hedge changes."""
         price = get_eth_usdc_price()
-        send_telegram_message(f"Preço atual ETH/USDC: {price:.2f}")
 
         lp = get_lp_position(self.address)
+        if lp and self.wallet is not None and not self.wallet.lp_positions:
+            self.wallet.lp_positions.append(lp)
+            ts = datetime.utcnow().strftime("%H:%M:%S")
+            send_telegram_message(
+                f"[{ts}] LP existente detectada {lp['lower']:.2f}-{lp['upper']:.2f}"
+            )
+
         if not lp:
-            lp = create_lp_position(self.wallet, price)
-            send_telegram_message("LP criada automaticamente")
+            if self._execute:
+                alloc = float(os.getenv("LP_ALLOCATION", "0.5"))
+                lp = create_lp_position(self.wallet, price, allocation=alloc)
+                ts = datetime.utcnow().strftime("%H:%M:%S")
+                send_telegram_message(
+                    f"[{ts}] LP criada {lp['lower']:.2f}-{lp['upper']:.2f} "
+                    f"com {lp['eth']:.4f} ETH / {lp['usdc']:.2f} USDC",
+                )
+            else:
+                ts = datetime.utcnow().strftime("%H:%M:%S")
+                send_telegram_message(f"[{ts}] Nenhuma LP ativa detectada")
+                return
 
         lower_price, upper_price = lp["lower"], lp["upper"]
         if abs(lower_price) > 1e5 or abs(upper_price) > 1e5:
-            lower_price = self._tick_to_price(lp["lower"])
-            upper_price = self._tick_to_price(lp["upper"])
+            lower_price = self._tick_to_price(lower_price)
+            upper_price = self._tick_to_price(upper_price)
         lp_prices = {
             "lower": lower_price,
             "upper": upper_price,
@@ -37,20 +62,42 @@ class BotLogic:
         }
 
         hedge_eth = get_eth_position(self.address, self.wallet)
-        if hedge_eth == 0 and lp["eth"] > 0:
-            set_hedge_position(lp["eth"], price, self.simulated, self.wallet)
-            send_telegram_message("Hedge criado automaticamente")
-            hedge_eth = lp["eth"]
-        elif abs(lp["eth"] - hedge_eth) > 0.01:
-            set_hedge_position(lp["eth"], price, self.simulated, self.wallet)
-            send_telegram_message("Hedge rebalanceado")
+        leverage = float(os.getenv("PERP_LEVERAGE", "5"))
+        max_hedge = float("inf")
+        if self.wallet is not None:
+            max_hedge = (self.wallet.usdc_balance * leverage) / price
+        target = min(lp_prices["eth"], max_hedge)
+        if abs(hedge_eth - target) > 0.01:
+            ts = datetime.utcnow().strftime("%H:%M:%S")
+            if self._execute:
+                set_hedge_position(target, price, self.simulated, self.wallet, leverage)
+                send_telegram_message(
+                    f"[{ts}] Hedge {hedge_eth:.4f} -> {target:.4f} ETH",
+                )
+                hedge_eth = target
+            else:
+                send_telegram_message(
+                    f"[{ts}] Sugerido hedge {hedge_eth:.4f} -> {target:.4f} ETH",
+                )
 
         if should_reposition(price, lp_prices):
-            move_range(self.wallet, price)
-            send_telegram_message("Range reposicionado")
+            old_lower, old_upper = lp_prices["lower"], lp_prices["upper"]
+            if self._execute:
+                lp_prices = move_range(self.wallet, price)
+                lower_price, upper_price = lp_prices["lower"], lp_prices["upper"]
+                ts = datetime.utcnow().strftime("%H:%M:%S")
+                send_telegram_message(
+                    f"[{ts}] Range {old_lower:.2f}-{old_upper:.2f} -> "
+                    f"{lower_price:.2f}-{upper_price:.2f}"
+                )
+            else:
+                ts = datetime.utcnow().strftime("%H:%M:%S")
+                send_telegram_message(
+                    f"[{ts}] Sugerido mover range {old_lower:.2f}-{old_upper:.2f}"
+                )
 
         print(
-            f"LP: [{lower_price:.2f}, {upper_price:.2f}] Exposição: {lp['eth']:.4f} ETH Hedge: {hedge_eth:.4f}"
+            f"LP: [{lower_price:.2f}, {upper_price:.2f}] Exposição: {lp_prices['eth']:.4f} ETH Hedge: {hedge_eth:.4f}"
         )
 
     @staticmethod

--- a/utils/prices.py
+++ b/utils/prices.py
@@ -1,3 +1,5 @@
+"""Retrieve ETH/USDC prices with cascading fallbacks."""
+
 import os
 import requests
 

--- a/utils/wallet_simulator.py
+++ b/utils/wallet_simulator.py
@@ -1,8 +1,8 @@
 class WalletSimulator:
     """In-memory simulator for testing without sending transactions."""
 
-    def __init__(self, initial_eth: float = 10.0, initial_usdc: float = 10000.0):
-        self.eth_balance = initial_eth
+    def __init__(self, initial_usdc: float = 10000.0):
+        self.eth_balance = 0.0
         self.usdc_balance = initial_usdc
         self.lp_positions = []
         self.hedge_positions = []
@@ -31,6 +31,15 @@ class WalletSimulator:
             self.eth_balance += amount / price
         print(f"[SIM] Swap {amount} {from_token} para {to_token} @ {price}")
 
-    def rebalance_hedge(self, target_eth):
-        self.hedge_positions = [{"eth": target_eth}]
-        print(f"[SIM] Hedge ajustado para {target_eth} ETH")
+    def rebalance_hedge(self, target_eth, price, leverage):
+        margin_required = abs(target_eth) * price / leverage
+        if margin_required > self.usdc_balance:
+            margin_required = self.usdc_balance
+            target_eth = (margin_required * leverage) / price
+        self.usdc_balance -= margin_required
+        self.hedge_positions = [
+            {"eth": target_eth, "margin": margin_required, "leverage": leverage}
+        ]
+        print(
+            f"[SIM] Hedge ajustado para {target_eth} ETH com margem {margin_required} USDC"
+        )


### PR DESCRIPTION
## Summary
- Introduce a `RUN_MODE` toggle to switch between spectator and full-automation behaviors
- Gate LP and hedge actions behind the selected mode, sending Telegram suggestions when observing only
- Document run modes and environment variables in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `RUN_MODE=spectator SIMULATED_WALLET_MODE=true POLL_INTERVAL=1 FALLBACK_ETH_PRICE=2000 PUBLIC_ADDRESS=0x0000000000000000000000000000000000000000 UNISWAP_SUBGRAPH=https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-arbitrum UNISWAP_POOL_ID=0x88f38662f45c78302b556271cd0a4da9d1cb1a0d timeout 5 python main.py`
- `RUN_MODE=full SIMULATED_WALLET_MODE=true POLL_INTERVAL=1 FALLBACK_ETH_PRICE=2000 PUBLIC_ADDRESS=0x0000000000000000000000000000000000000000 UNISWAP_SUBGRAPH=https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-arbitrum UNISWAP_POOL_ID=0x88f38662f45c78302b556271cd0a4da9d1cb1a0d timeout 5 python main.py <<'EOF'
1000
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68954eaddc488327821a156585018974