### PR TITLE
Add spectator operation mode to hedge bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Hedge Bot MVP
 
 Bot de hedge para posições de LP WETH/USDC na Uniswap v3 com integração à Hyperliquid.
+Agora o bot possui dois modos de operação: **espectador**, que apenas envia alertas e recomendações, e **ativo**, que executa as operações automaticamente.
 
 ## Configuração
 
@@ -8,6 +9,8 @@ Bot de hedge para posições de LP WETH/USDC na Uniswap v3 com integração à H
 2. Instale dependências: `pip install -r requirements.txt`.
 3. Execute o bot: `python main.py` e escolha entre carteira de **teste** ou **real** quando solicitado.
    Ao usar o modo de teste será pedido o saldo inicial de ETH e USDC a ser utilizado.
+4. Escolha o modo de operação **espectador** ou **ativo** quando perguntado.
+   Para automatizar, defina `BOT_MODE=espectador` ou `ativo` no `.env`.
 
 ## Modo de simulação
 
@@ -16,5 +19,6 @@ Para automatizar, defina `SIMULATED_WALLET_MODE=True` ou `False` no `.env` e a p
 Mesmo em simulação o bot consulta dados reais das APIs.
 
 Ao iniciar um ciclo o bot verifica se já existem posições de LP na Uniswap e de hedge na Hyperliquid,
-criando-as se necessário. A troca de faixa da LP considera o possível ganho em taxas menos o custo de gas,
+criando-as se necessário quando no modo ativo. No modo espectador são enviados apenas alertas de recomendação.
+A troca de faixa da LP considera o possível ganho em taxas menos o custo de gas,
 e o hedge é ajustado dinamicamente para manter exposição neutra.

--- a/main.py
+++ b/main.py
@@ -23,6 +23,16 @@ if simulated_env is None:
 else:
     SIMULATED = simulated_env.lower() == "true"
 
+mode_env = os.getenv("BOT_MODE")
+if mode_env is None:
+    mode_choice = (
+        input("Modo de operação? [espectador/ativo]: ").strip().lower()
+        or "espectador"
+    )
+else:
+    mode_choice = mode_env.lower()
+MODE = "active" if mode_choice in ("ativo", "active") else "spectator"
+
 subgraph = os.getenv("UNISWAP_SUBGRAPH") or input(
     "URL do subgrafo Uniswap (enter para padrão Arbitrum): "
 ).strip()
@@ -45,9 +55,10 @@ if SIMULATED:
         usdc_bal = 10000.0
     wallet = WalletSimulator(initial_usdc=usdc_bal)
 
-bot = BotLogic(wallet, ADDRESS, simulated=SIMULATED)
+bot = BotLogic(wallet, ADDRESS, simulated=SIMULATED, mode=MODE)
 
-send_telegram_message("🚀 Bot iniciado com sucesso!")
+mode_label = "ativo" if MODE == "active" else "espectador"
+send_telegram_message(f"🚀 Bot iniciado no modo {mode_label}!")
 
 if __name__ == "__main__":
     while True:


### PR DESCRIPTION
## Summary
- add spectator and active operation modes
- send telegram alerts with recommendations in spectator mode
- document new modes and environment variable configuration

## Testing
- `python -m py_compile main.py utils/logic.py`


------
https://chatgpt.com/codex/tasks/task_e_6896e29156d88327aca69a1e3a712fc0