### PR TITLE
Use Uniswap bundle for ETH price fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,13 +20,17 @@ INTERVAL = int(interval_env)
 
 mode_env = os.getenv("BOT_MODE")
 if mode_env is None:
-    mode_choice = (
-        input("Modo de operação? [espectador/ativo]: ").strip().lower()
-        or "espectador"
+    spectator_choice = (
+        input("Ativar modo espectador? (s/N): ").strip().lower()
     )
+    MODE = "spectator" if spectator_choice == "s" else "active"
 else:
-    mode_choice = mode_env.lower()
-MODE = "active" if mode_choice in ("ativo", "active") else "spectator"
+    mode_choice = mode_env.strip().lower()
+    MODE = (
+        "spectator"
+        if mode_choice in ("s", "sim", "spectator", "espectador")
+        else "active"
+    )
 
 subgraph = os.getenv("UNISWAP_SUBGRAPH") or input(
     "URL do subgrafo Uniswap (enter para padrão Arbitrum): "


### PR DESCRIPTION
## Summary
- query Uniswap's `bundle` for ETH/USD price when exchange APIs fail
- retain pool query as secondary Uniswap fallback
- require "s" input to enable spectator mode

## Testing
- `pytest`
- `python - <<'PY'
from utils.prices import get_eth_usdc_price
try:
    print('Price:', get_eth_usdc_price())
except Exception as e:
    print('Error during price fetch:', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6898207d9f108327b91e3cfcabca3e86