### PR TITLE
Remove simulated wallet and simplify bot logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,8 +91,7 @@ send_telegram_message(
     + " | ".join(status_msgs)
 )
 
-wallet = None
-bot = BotLogic(wallet, ADDRESS, mode=MODE)
+bot = BotLogic(ADDRESS, mode=MODE)
 
 if __name__ == "__main__":
     while True:


### PR DESCRIPTION
## Summary
- Drop simulated wallet usage, instantiating bot logic with only an address
- Refactor bot logic to operate without wallet state and add LP detection flag
- Simplify Uniswap helpers to log intended actions rather than simulate wallet operations

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `BOT_MODE=espectador PUBLIC_ADDRESS=0x0000000000000000000000000000000000000000 python main.py <<'EOF'

EOF` *(fails: HTTPSConnectionPool(host='api.thegraph.com', port=443): Max retries exceeded with url: /subgraphs/name/ianlapham/uniswap-v3-arbitrum (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_6898266600b48327a27c32b35c737dc1