### PR TITLE
Support separate Hyperliquid address

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,7 +91,7 @@ send_telegram_message(
     + " | ".join(status_msgs)
 )
 
-bot = BotLogic(ADDRESS, mode=MODE)
+bot = BotLogic(ADDRESS, hedge_address=HL_ADDRESS, mode=MODE)
 
 if __name__ == "__main__":
     while True:

--- a/utils/logic.py
+++ b/utils/logic.py
@@ -10,8 +10,9 @@ from .telegram import send_telegram_message
 class BotLogic:
     """Encapsula o ciclo principal de operações do bot."""
 
-    def __init__(self, address: str, mode: str = "active"):
+    def __init__(self, address: str, hedge_address: str | None = None, mode: str = "active"):
         self.address = address
+        self.hedge_address = hedge_address or address
         self.mode = mode
         self._notified_lp = False
 
@@ -51,7 +52,7 @@ class BotLogic:
         }
 
         # Calcula hedge necessário e envia ordens ou alertas
-        hedge_eth = get_eth_position(self.address)
+        hedge_eth = get_eth_position(self.hedge_address)
         leverage = float(os.getenv("PERP_LEVERAGE", "5"))
         max_hedge = float(os.getenv("MAX_HEDGE_ETH", "1000000000"))
         target = min(lp["eth"], max_hedge)


### PR DESCRIPTION
## Summary
- allow BotLogic to use a dedicated Hyperliquid address
- wire main entrypoint to pass `HYPERLIQUID_ADDRESS`

## Testing
- `python -m py_compile main.py utils/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6898af50aaac83278a04d6491f1f0353