### PR TITLE
feat: add setup script and offline tolerance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,3 @@
 RPC_URL_ARBITRUM=https://arb1.arbitrum.io/rpc
-RPC_FALLBACKS=https://rpc.ankr.com/arbitrum,https://arbitrum.llamarpc.com
-HYPERLIQUID_API_KEY=
-HYPERLIQUID_API_SECRET=
-WALLET_ADDRESS=
+RPC_FALLBACKS=https://arbitrum.llamarpc.com,https://rpc.ankr.com/arbitrum
+HYPERLIQUID_WALLET_ADDRESS=0x2234a5bcf47d5a0676049564b9573a17dde56bc5

--- a/README.md
+++ b/README.md
@@ -1,22 +1,45 @@
 # Hedge Bot MVP
 
-Bot de hedge para posições de LP WETH/USDC na Uniswap v3 com integração à Hyperliquid.
+Bot de monitoramento para posições de LP WETH/USDC na Uniswap v3 com leitura de posições na Hyperliquid.
 
 ## Configuração
 
 1. Copie `.env.example` para `.env` e preencha as variáveis:
    - `RPC_URL_ARBITRUM`
    - `RPC_FALLBACKS`
-   - `HYPERLIQUID_API_KEY` e `HYPERLIQUID_API_SECRET`
-   - `WALLET_ADDRESS`
-2. Instale as dependências:
+   - `HYPERLIQUID_WALLET_ADDRESS`
+2. Instale as dependências com script de fallback:
    ```bash
-   pip install -r requirements.txt
+   bash scripts/setup_env.sh
    ```
 3. Execute o bot:
    ```bash
    python main.py
    ```
 
-O script imprime o estado do pool WETH/USDC (sqrtPriceX96 e tick) e uma cotação via QuoterV2,
-utilizando o SDK oficial da Hyperliquid para evitar o erro de import. Nunca versione suas chaves de API.
+O script consulta o estado do pool WETH/USDC 0.05% na Uniswap v3 e a posição de hedge na Hyperliquid
+utilizando apenas o endereço público, emitindo alertas quando o preço se aproxima dos limites da posição LP.
+
+### Testes
+
+Para rodar testes sem acesso à rede:
+
+```bash
+OFFLINE=1 python -m pytest -q
+```
+
+Sem a variável `OFFLINE`, os testes tentam acessar o RPC e serão pulados caso nenhum endpoint esteja disponível.
+
+### Comportamento offline
+
+Se todos os RPCs estiverem indisponíveis, o bot exibe:
+
+```
+[WARN] All RPC endpoints unavailable; running in degraded mode (no chain reads)
+```
+
+Caso a API da Hyperliquid não responda, será logado:
+
+```
+[WARN] Hyperliquid API unreachable (read-only); skipping this cycle
+```

--- a/main.py
+++ b/main.py
@@ -1,10 +1,9 @@
-placeholder
 import os
 import time
 
 from dotenv import load_dotenv
 
-from utils.uniswap import UniswapClient
+from utils.uniswap import UniswapClient, RpcUnavailable
 from utils.hyperliquid import HyperliquidAPI
 from utils.logic import BotLogic
 
@@ -13,13 +12,25 @@ def main() -> None:
     load_dotenv()
     rpc_url = os.getenv("RPC_URL_ARBITRUM")
     fallbacks = os.getenv("RPC_FALLBACKS", "")
-    uniswap = UniswapClient(rpc_url=rpc_url, fallbacks=fallbacks)
-    hyper = HyperliquidAPI(os.getenv("WALLET_ADDRESS"))
-    bot = BotLogic(uniswap, hyper)
+    wallet = os.getenv("HYPERLIQUID_WALLET_ADDRESS")
+    token_id_env = os.getenv("UNISWAP_POSITION_TOKEN_ID")
+    token_id = int(token_id_env) if token_id_env else None
+
+    hyper = HyperliquidAPI(wallet)
+    bot = BotLogic(None, hyper, lp_token_id=token_id)
     try:
         while True:
-            bot.check_and_hedge()
-            time.sleep(20)
+            if bot.uniswap is None:
+                try:
+                    bot.uniswap = UniswapClient(rpc_url=rpc_url, fallbacks=fallbacks)
+                except RpcUnavailable:
+                    print("[WARN] All RPC endpoints unavailable; running in degraded mode (no chain reads)")
+            try:
+                bot.check_and_alert()
+            except RpcUnavailable:
+                print("[WARN] All RPC endpoints unavailable; running in degraded mode (no chain reads)")
+                bot.uniswap = None
+            time.sleep(30)
     except KeyboardInterrupt:
         print("Exiting...")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
-web3
-hexbytes
-python-dotenv
-tenacity
-hyperliquid-python-sdk
-requests
+web3==6.18.0
+eth-account==0.13.3
+eth-abi==4.2.1
+eth-utils==4.1.1
+hexbytes==0.3.1
+python-dotenv==1.0.1
+tenacity==8.2.3
+requests==2.32.3
+hyperliquid-python-sdk==0.9.3

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python -m pip install --upgrade pip setuptools wheel || true
+if ! pip install -r requirements.txt; then
+  echo "[WARN] Falling back to web3==6.17.2"
+  sed -i 's/^web3==6\.18\.0$/web3==6.17.2/' requirements.txt
+  pip install -r requirements.txt
+fi

--- a/tests/test_uniswap.py
+++ b/tests/test_uniswap.py
@@ -1,10 +1,25 @@
 import os
+import pytest
 
-from utils.uniswap import UniswapClient, POOL_WETH_USDC_005
+from utils.uniswap import (
+    UniswapClient,
+    POOL_WETH_USDC_005,
+    get_web3_client,
+    RpcUnavailable,
+)
 
 
+@pytest.mark.skipif(os.getenv("OFFLINE") == "1", reason="offline")
 def test_get_pool_state():
-    client = UniswapClient(os.getenv("RPC_URL_ARBITRUM", "https://arb1.arbitrum.io/rpc"))
+    rpc = os.getenv("RPC_URL_ARBITRUM", "https://arb1.arbitrum.io/rpc")
+    fallbacks = os.getenv("RPC_FALLBACKS", "")
+    try:
+        w3 = get_web3_client(rpc, fallbacks)
+    except RpcUnavailable:
+        pytest.skip("no RPC available")
+    if not w3.is_connected():  # pragma: no cover - defensive
+        pytest.skip("no RPC available")
+    client = UniswapClient(rpc_url=rpc, fallbacks=fallbacks)
     state = client.get_pool_state(POOL_WETH_USDC_005)
     assert state["sqrtPriceX96"] > 0
     assert isinstance(state["tick"], int)

--- a/utils/logic.py
+++ b/utils/logic.py
@@ -2,35 +2,53 @@
 
 from __future__ import annotations
 
-from .uniswap import UniswapClient, POOL_WETH_USDC_005
+from .uniswap import UniswapClient, POOL_WETH_USDC_005, RpcUnavailable
 from .hyperliquid import HyperliquidAPI
 
 
 class BotLogic:
-    """Simple loop that reads price data and maintains a hedge."""
+    """Monitor pool state and Hyperliquid position and raise alerts."""
 
-    def __init__(self, uniswap: UniswapClient, hyperliquid: HyperliquidAPI):
+    def __init__(
+        self,
+        uniswap: UniswapClient | None,
+        hyperliquid: HyperliquidAPI,
+        lp_token_id: int | None = None,
+        alert_ticks: int = 100,
+    ) -> None:
         self.uniswap = uniswap
         self.hyperliquid = hyperliquid
+        self.lp_token_id = lp_token_id
+        self.alert_ticks = alert_ticks
 
-    def check_and_hedge(self) -> None:
-        """Print pool state, quote price and adjust hedge if needed."""
+    def check_and_alert(self) -> None:
+        """Print pool state and warn if near LP bounds."""
 
-        try:
-            state = self.uniswap.get_pool_state(POOL_WETH_USDC_005)
-            print(
-                f"Pool sqrtPriceX96={state['sqrtPriceX96']} tick={state['tick']}"
-            )
-        except Exception as exc:
-            print(f"[LOGIC] Failed to fetch pool state: {exc}")
-            return
+        tick = None
+        if self.uniswap is not None:
+            try:
+                state = self.uniswap.get_pool_state(POOL_WETH_USDC_005)
+                tick = state["tick"]
+                print(f"Pool sqrtPriceX96={state['sqrtPriceX96']} tick={tick}")
+            except RpcUnavailable:
+                raise
+            except Exception as exc:
+                print(f"[LOGIC] Failed to fetch pool state: {exc}")
+        else:
+            print("[LOGIC] Skipping pool state (no RPC)")
 
-        try:
-            quote = self.uniswap.get_quote_weth_usdc(10**18)
-            print(f"Quote 1 WETH -> {quote['amountOut']} USDC")
-        except Exception as exc:
-            print(f"[LOGIC] Failed to fetch quote: {exc}")
+        pos = self.hyperliquid.get_position("ETH")
+        print(f"Hyperliquid position: {pos}")
 
-        # Example strategy: stay delta neutral (no open position)
-        self.hyperliquid.ensure_hedge("ETH", 0.0)
+        if tick is not None and self.lp_token_id is not None and self.uniswap is not None:
+            try:
+                lower, upper = self.uniswap.get_position_bounds(self.lp_token_id)
+                if tick <= lower + self.alert_ticks:
+                    print("[ALERT] Price near lower bound")
+                elif tick >= upper - self.alert_ticks:
+                    print("[ALERT] Price near upper bound")
+            except RpcUnavailable:
+                raise
+            except Exception as exc:
+                print(f"[LOGIC] Failed to fetch position bounds: {exc}")
 


### PR DESCRIPTION
## Summary
- add environment template and reproducible Python pins
- implement resilient Uniswap RPC client with retries
- add read-only Hyperliquid fallback and monitoring loop

## Testing
- `bash scripts/setup_env.sh` *(fails: Could not find a version that satisfies the requirement web3==6.18.0)*
- `python -c "import web3, dotenv; print(web3.__version__)"`
- `HYPERLIQUID_WALLET_ADDRESS=0xdead python main.py` *(shows degraded mode warnings)*
- `OFFLINE=1 python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c873b6588327b64e26fbc1ca349e